### PR TITLE
Implement regex constraint for String fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ defmodule MyApp.Schema do
     arg(:max, :integer, description: "Maximum value allowed")
     arg(:min_items, :integer, description: "Minimum number of items allowed in a list")
     arg(:max_items, :integer, description: "Maximum number of items allowed in a list")
+    arg(:regex, :string, description: "Pattern to match for a string")
   end
 
   query do
@@ -101,7 +102,7 @@ field :my_list, list_of(:integer) do
 end
 
 field :my_field, :integer do
-  arg :my_arg, non_null(:string), directives: [constraints: [min: 10]]
+  arg :my_arg, non_null(:string), directives: [constraints: [min: 10, regex: "^[a-zA-Z]+$"]]
 
   resolve(&MyResolver.resolve/3)
 end

--- a/lib/constraints/max.ex
+++ b/lib/constraints/max.ex
@@ -3,7 +3,7 @@ defmodule AbsintheHelpers.Constraints.Max do
 
   @behaviour AbsintheHelpers.Constraint
 
-  def call(node = %{items: _items}, {:max, _min}) do
+  def call(node = %{items: _items}, {:max, _max}) do
     {:ok, node}
   end
 

--- a/lib/constraints/regex.ex
+++ b/lib/constraints/regex.ex
@@ -6,7 +6,7 @@ defmodule AbsintheHelpers.Constraints.Regex do
   @behaviour AbsintheHelpers.Constraint
 
   def call(node = %{data: data}, {:regex, regex}) do
-    if data =~ regex do
+    if data =~ Regex.compile!(regex) do
       {:ok, node}
     else
       {:error, :invalid_format, %{regex: regex}}

--- a/lib/constraints/regex.ex
+++ b/lib/constraints/regex.ex
@@ -1,0 +1,19 @@
+defmodule AbsintheHelpers.Constraints.Regex do
+  @moduledoc """
+  Applies regex constraint on node data only when the data is binary.
+  """
+
+  @behaviour AbsintheHelpers.Constraint
+
+  def call(node = %{items: _items}, {:regex, _min}) do
+    {:ok, node}
+  end
+
+  def call(node = %{data: data}, {:regex, regex}) when is_binary(data) do
+    if data =~ regex do
+      {:ok, node}
+    else
+      {:error, :invalid_format, %{regex: regex}}
+    end
+  end
+end

--- a/lib/constraints/regex.ex
+++ b/lib/constraints/regex.ex
@@ -1,15 +1,11 @@
 defmodule AbsintheHelpers.Constraints.Regex do
   @moduledoc """
-  Applies regex constraint on node data only when the data is binary.
+  Applies regex constraint on node data. This constraint can only be applied to String types.
   """
 
   @behaviour AbsintheHelpers.Constraint
 
-  def call(node = %{items: _items}, {:regex, _min}) do
-    {:ok, node}
-  end
-
-  def call(node = %{data: data}, {:regex, regex}) when is_binary(data) do
+  def call(node = %{data: data}, {:regex, regex}) do
     if data =~ regex do
       {:ok, node}
     else

--- a/lib/directives/constraints.ex
+++ b/lib/directives/constraints.ex
@@ -30,8 +30,10 @@ defmodule AbsintheHelpers.Directives.Constraints do
 
     arg(:min, :integer, description: "Minimum value allowed")
     arg(:max, :integer, description: "Maximum value allowed")
+
     arg(:min_items, :integer, description: "Minimum number of items allowed in a list")
     arg(:max_items, :integer, description: "Maximum number of items allowed in a list")
+
     arg(:regex, :string, description: "Pattern to match for a string")
 
     expand(&__MODULE__.expand_constraints/2)

--- a/lib/directives/constraints.ex
+++ b/lib/directives/constraints.ex
@@ -5,11 +5,12 @@ defmodule AbsintheHelpers.Directives.Constraints do
   Supports:
   - `:min`, `:max`: For numbers and string lengths
   - `:min_items`, `:max_items`: For lists
+  - `:regex`: For strings
 
   Applicable to scalars (:string, :integer, :float, :decimal) and lists.
 
   Example:
-      field :username, :string, directives: [constraints: [min: 3, max: 20]]
+      field :username, :string, directives: [constraints: [min: 3, max: 20, regex: "^[a-zA-Z]+$"]]
       arg :tags, list_of(:string), directives: [constraints: [max_items: 5, max: 10]]
 
   Constraints are automatically enforced during query execution.

--- a/lib/directives/constraints.ex
+++ b/lib/directives/constraints.ex
@@ -20,7 +20,7 @@ defmodule AbsintheHelpers.Directives.Constraints do
   alias Absinthe.Blueprint.TypeReference.{List, NonNull}
 
   @constraints %{
-    string: [:min, :max],
+    string: [:min, :max, :regex],
     number: [:min, :max],
     list: [:min, :max, :min_items, :max_items]
   }
@@ -32,6 +32,7 @@ defmodule AbsintheHelpers.Directives.Constraints do
     arg(:max, :integer, description: "Maximum value allowed")
     arg(:min_items, :integer, description: "Minimum number of items allowed in a list")
     arg(:max_items, :integer, description: "Maximum number of items allowed in a list")
+    arg(:regex, :string, description: "Pattern to match for a string")
 
     expand(&__MODULE__.expand_constraints/2)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule AbsintheHelpers.MixProject do
   def project do
     [
       app: :absinthe_helpers,
-      version: "0.1.8",
+      version: "0.1.9",
       elixir: "~> 1.16",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/absinthe_helpers/constraints/regex_test.exs
+++ b/test/absinthe_helpers/constraints/regex_test.exs
@@ -3,15 +3,15 @@ defmodule AbsintheHelpers.Constraints.RegexTest do
 
   alias AbsintheHelpers.Constraints.Regex
 
-  test "regex constraint passes" do
+  test "returns :ok tuple on regex match" do
     input = %{data: "username"}
 
-    assert {:ok, %{data: "username"}} = Regex.call(input, {:regex, ~r/^[a-z]*$/})
+    assert {:ok, %{data: "username"}} = Regex.call(input, {:regex, "^[a-z]*$"})
   end
 
-  test "regex constraint fails" do
+  test "returns invalid_format error on regex match failure" do
     input = %{data: "user.name"}
 
-    assert {:error, :invalid_format, %{regex: ~r/^[a-z]*$/}} = Regex.call(input, {:regex, ~r/^[a-z]*$/})
+    assert {:error, :invalid_format, %{regex: "^[a-z]*$"}} = Regex.call(input, {:regex, "^[a-z]*$"})
   end
 end

--- a/test/absinthe_helpers/constraints/regex_test.exs
+++ b/test/absinthe_helpers/constraints/regex_test.exs
@@ -1,0 +1,17 @@
+defmodule AbsintheHelpers.Constraints.RegexTest do
+  use ExUnit.Case, async: true
+
+  alias AbsintheHelpers.Constraints.Regex
+
+  test "regex constraint passes" do
+    input = %{data: "username"}
+
+    assert {:ok, %{data: "username"}} = Regex.call(input, {:regex, ~r/^[a-z]*$/})
+  end
+
+  test "regex constraint fails" do
+    input = %{data: "user.name"}
+
+    assert {:error, :invalid_format, %{regex: ~r/^[a-z]*$/}} = Regex.call(input, {:regex, ~r/^[a-z]*$/})
+  end
+end


### PR DESCRIPTION
We'd like to have regex constraints for Strings. This PR implements that. 
Additionally, I've got two questions, one out of scope for this PR.

1. Seems like validations `halt` on first validation error, i.e. we don't go through all the validations for a single field. Meaning that clients would need to make multiple requests just to see all the errors. Should we not change that?
2. I'm open to discussions about how to name this constraint, I went with the one that came to mind first.

I've implemented a separate test case because of the 1st bullet point above otherwise I think I'd add that test to an existing test case.