### PR TITLE
Add mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+elixir = "1.16.2-otp-26"
+erlang = "26.2.5"


### PR DESCRIPTION
Adds mise.toml tool-version pins derived from existing CI setup-* actions / .tool-versions, as prep for migrating to stepsecurity/setup-mise. No workflow behavior changes yet.