### PR TITLE
Migrate to step-security/mise-action for tool installation

### DIFF
--- a/.github/actions.lock.yaml
+++ b/.github/actions.lock.yaml
@@ -1,5 +1,5 @@
 version: 1
-generated_at: 2026-06-11T15:33:13Z
+generated_at: 2026-08-03T18:41:15Z
 internal: []
 trusted:
   - action: actions/checkout
@@ -8,48 +8,61 @@ trusted:
     occurrences:
       34e114876b0b11c390a56381ad16ebd13914f8d5:
         .github/workflows/ci.yaml:
+          - jobs.static.steps.[1].uses
+          - jobs.test.steps.[1].uses
+          - jobs.permit.steps.[1].uses
+          - jobs.publish.steps.[1].uses
+        .github/workflows/dev-publish.yaml:
+          - jobs.dev-publish.steps.[1].uses
+external:
+  - action: step-security/harden-runner
+    refs:
+      - 9af89fc71515a100421586dfdb3dc9c984fbf411
+    occurrences:
+      9af89fc71515a100421586dfdb3dc9c984fbf411:
+        .github/workflows/ci.yaml:
           - jobs.static.steps.[0].uses
           - jobs.test.steps.[0].uses
           - jobs.permit.steps.[0].uses
           - jobs.publish.steps.[0].uses
         .github/workflows/dev-publish.yaml:
           - jobs.dev-publish.steps.[0].uses
-  - action: runs-on/cache
+  - action: step-security/mise-action
     refs:
-      - a5f51d6f3fece787d03b7b4e981c82538a0654ed
+      - 2796166110dee826668caddd4bffedae5116e7cd
     occurrences:
-      a5f51d6f3fece787d03b7b4e981c82538a0654ed:
+      2796166110dee826668caddd4bffedae5116e7cd:
         .github/workflows/ci.yaml:
-          - jobs.static.steps.[4].uses
-          - jobs.static.steps.[6].uses
-          - jobs.test.steps.[4].uses
-          - jobs.test.steps.[6].uses
-  - action: runs-on/cache/restore
-    refs:
-      - a5f51d6f3fece787d03b7b4e981c82538a0654ed
-    occurrences:
-      a5f51d6f3fece787d03b7b4e981c82538a0654ed:
+          - jobs.static.steps.[2].uses
+          - jobs.test.steps.[2].uses
+          - jobs.publish.steps.[2].uses
         .github/workflows/dev-publish.yaml:
-          - jobs.dev-publish.steps.[2].uses
-  - action: runs-on/cache/save
+          - jobs.dev-publish.steps.[4].uses
+  - action: step-security/runs-on-cache
     refs:
-      - a5f51d6f3fece787d03b7b4e981c82538a0654ed
+      - c5b0cba15d05488ebc630ad8d1e95b3d9b35ac73
     occurrences:
-      a5f51d6f3fece787d03b7b4e981c82538a0654ed:
+      c5b0cba15d05488ebc630ad8d1e95b3d9b35ac73:
         .github/workflows/ci.yaml:
-          - jobs.permit.steps.[3].uses
-external:
-  - action: erlef/setup-beam
+          - jobs.static.steps.[5].uses
+          - jobs.static.steps.[7].uses
+          - jobs.test.steps.[5].uses
+          - jobs.test.steps.[7].uses
+  - action: step-security/runs-on-cache/restore
     refs:
-      - fc68ffb90438ef2936bbb3251622353b3dcb2f93
+      - c5b0cba15d05488ebc630ad8d1e95b3d9b35ac73
     occurrences:
-      fc68ffb90438ef2936bbb3251622353b3dcb2f93:
-        .github/workflows/ci.yaml:
-          - jobs.static.steps.[1].uses
-          - jobs.test.steps.[1].uses
-          - jobs.publish.steps.[1].uses
+      c5b0cba15d05488ebc630ad8d1e95b3d9b35ac73:
         .github/workflows/dev-publish.yaml:
           - jobs.dev-publish.steps.[3].uses
+  - action: step-security/runs-on-cache/save
+    refs:
+      - c5b0cba15d05488ebc630ad8d1e95b3d9b35ac73
+    occurrences:
+      c5b0cba15d05488ebc630ad8d1e95b3d9b35ac73:
+        .github/workflows/ci.yaml:
+          - jobs.permit.steps.[4].uses
 local: []
 docker: []
 dynamic: []
+nested_floating_deps: []

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,14 +53,8 @@ jobs:
           ref: ${{ env.SHA }}
           clean: false
           persist-credentials: true
-      - name: Setup Elixir
-        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
-        env:
-          ImageOS: ${{ matrix.versions.runner-os }}
-        with:
-          elixir-version: ${{ matrix.versions.elixir-version }}
-          otp-version: ${{ matrix.versions.otp-version }}
-          version-type: strict
+      - name: Setup mise
+        uses: step-security/mise-action@2796166110dee826668caddd4bffedae5116e7cd # v4.2.0
       - name: Get SHA sum (HASH) of relevant files
         id: hash
         run: |
@@ -136,14 +130,8 @@ jobs:
           ref: ${{ env.SHA }}
           clean: false
           persist-credentials: true
-      - name: Setup Elixir
-        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
-        env:
-          ImageOS: ${{ matrix.versions.runner-os }}
-        with:
-          elixir-version: ${{ matrix.versions.elixir-version }}
-          otp-version: ${{ matrix.versions.otp-version }}
-          version-type: strict
+      - name: Setup mise
+        uses: step-security/mise-action@2796166110dee826668caddd4bffedae5116e7cd # v4.2.0
       - name: Get SHA sum (HASH) of relevant files
         id: hash
         run: |
@@ -260,14 +248,8 @@ jobs:
           ref: ${{ env.SHA }}
           clean: false
           persist-credentials: true
-      - name: Setup Elixir
-        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
-        env:
-          ImageOS: ${{ env.RUNNER_OS }}
-        with:
-          elixir-version: ${{ env.ELIXIR_VERSION }}
-          otp-version: ${{ env.OTP_VERSION }}
-          version-type: strict
+      - name: Setup mise
+        uses: step-security/mise-action@2796166110dee826668caddd4bffedae5116e7cd # v4.2.0
       - name: Hex auth
         run: mix hex.organization auth fresha --key ${{ secrets.HEX_ORGANIZATION_WRITE_KEY }}
         shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,6 +55,8 @@ jobs:
           persist-credentials: true
       - name: Setup mise
         uses: step-security/mise-action@2796166110dee826668caddd4bffedae5116e7cd # v4.2.0
+      - name: Install Hex + Rebar
+        run: mix local.hex --force && mix local.rebar --force
       - name: Get SHA sum (HASH) of relevant files
         id: hash
         run: |
@@ -132,6 +134,8 @@ jobs:
           persist-credentials: true
       - name: Setup mise
         uses: step-security/mise-action@2796166110dee826668caddd4bffedae5116e7cd # v4.2.0
+      - name: Install Hex + Rebar
+        run: mix local.hex --force && mix local.rebar --force
       - name: Get SHA sum (HASH) of relevant files
         id: hash
         run: |
@@ -250,6 +254,8 @@ jobs:
           persist-credentials: true
       - name: Setup mise
         uses: step-security/mise-action@2796166110dee826668caddd4bffedae5116e7cd # v4.2.0
+      - name: Install Hex + Rebar
+        run: mix local.hex --force && mix local.rebar --force
       - name: Hex auth
         run: mix hex.organization auth fresha --key ${{ secrets.HEX_ORGANIZATION_WRITE_KEY }}
         shell: bash

--- a/.github/workflows/dev-publish.yaml
+++ b/.github/workflows/dev-publish.yaml
@@ -53,14 +53,8 @@ jobs:
           key: ${{ runner.os }}-${{ env.REPOSITORY }}-approval-${{ steps.hash.outputs.HASH }}
           path: approval.txt
           fail-on-cache-miss: true
-      - name: Setup Elixir
-        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
-        env:
-          ImageOS: ${{ env.RUNNER_OS }}
-        with:
-          elixir-version: ${{ env.ELIXIR_VERSION }}
-          otp-version: ${{ env.OTP_VERSION }}
-          version-type: strict
+      - name: Setup mise
+        uses: step-security/mise-action@2796166110dee826668caddd4bffedae5116e7cd # v4.2.0
       - name: Hex auth
         run: mix hex.organization auth fresha --key ${{ secrets.HEX_ORGANIZATION_WRITE_KEY }}
         shell: bash

--- a/.github/workflows/dev-publish.yaml
+++ b/.github/workflows/dev-publish.yaml
@@ -55,6 +55,8 @@ jobs:
           fail-on-cache-miss: true
       - name: Setup mise
         uses: step-security/mise-action@2796166110dee826668caddd4bffedae5116e7cd # v4.2.0
+      - name: Install Hex + Rebar
+        run: mix local.hex --force && mix local.rebar --force
       - name: Hex auth
         run: mix hex.organization auth fresha --key ${{ secrets.HEX_ORGANIZATION_WRITE_KEY }}
         shell: bash


### PR DESCRIPTION
## Summary
- Replaces `erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1` with a single `step-security/mise-action@2796166110dee826668caddd4bffedae5116e7cd # v4.2.0` step, reading Elixir/Erlang versions from the repo's `mise.toml` / `.tool-versions` (already merged to `main`), across all 4 occurrences:
  - `.github/workflows/ci.yaml`: jobs `static`, `test`, `publish`
  - `.github/workflows/dev-publish.yaml`: job `dev-publish`
- No downstream steps referenced `setup-beam` step outputs, so no step `id`/output-shim was needed.
- Regenerated `.github/actions.lock.yaml` via `platform-tribe-actions` alflow scripts to reflect the new `step-security/mise-action` step. No internal `freshaengineering/*` action pins needed bumping and no external re-pins changed in this run (this repo doesn't use `platform-tribe-actions/buildx`).

## Test plan
- [ ] `Elixir CI Checks` workflow (`ci.yaml`) runs on push/PR and the `static`, `test`, and `publish` jobs successfully set up Elixir/Erlang via mise and complete credo/format/tests/publish --dry-run
- [ ] `Elixir Dev Publish` workflow (`dev-publish.yaml`) can still be manually dispatched and successfully sets up Elixir/Erlang via mise before publishing the dev package

🤖 Generated with [Claude Code](https://claude.com/claude-code)